### PR TITLE
Use standardized error string for EINTR, just like ETERM and EAGAIN

### DIFF
--- a/src/pre_generated-zmq.nobj.c
+++ b/src/pre_generated-zmq.nobj.c
@@ -2159,6 +2159,9 @@ static const char *get_zmq_strerror() {
 	case EAGAIN:
 		return "timeout";
 		break;
+	case EINTR:
+		return "interrupted";
+		break;
 #if defined(ETERM)
 	case ETERM:
 		return "closed";

--- a/zmq.nobj.lua
+++ b/zmq.nobj.lua
@@ -46,6 +46,9 @@ static const char *get_zmq_strerror() {
 	case EAGAIN:
 		return "timeout";
 		break;
+	case EINTR:
+		return "interrupted";
+		break;
 #if defined(ETERM)
 	case ETERM:
 		return "closed";


### PR DESCRIPTION
The zmq functions now use "interrupted" instead of the system-specific
strerror() result for any EINTR errors.  This makes it easy to test for
those and retry any interrupted function calls.
